### PR TITLE
RFC: Add support for a general mechanism of setting Rust compiler flags via Cargo

### DIFF
--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -1,4 +1,4 @@
-- Feature Name: `rustflag`
+- Feature Name: `cargo_cli_rustflag`
 - Start Date: 2022-08-18
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
@@ -8,23 +8,22 @@
 
 One paragraph explanation of the feature.
 
-This RFC aims to improve the experience of enabling user specified Rust compiler flags
-when invoking a build of a Rust project through Cargo, which most Rust developers use
-to build their project. This feature would allow a Rust developer to selectively choose
-which rustc flags are set when inoking the Rust compiler for a given crate.
+This RFC aims to improve the experience of enabling Rust compiler flags for specific crates when building Rust projects
+by adding a new option, `--rustflag=<RUSTFLAG>`. This would have the same effect as `cargo rustc -- <RUSTFLAG>` but would
+also be available for use by other subcommands such as `bench, build, check, run` and `test`.
 
 # Motivation
 [motivation]: #motivation
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-Running a build of a Rust project via Cargo, there are limitations on trying to set Rust compiler flags. Since Cargo is aware of
-all crates being built in the dependency graph, cargo is properly positioned to be able to set Rust compiler flags  
+Today, there currently exists multiple ways of specifying `RUSTFLAGS` to pass to invocations of the Rust compiler.
+All of the existing ways have the limitation of not being able to specify which invocation of rustc the compiler flag
+is set for.
+
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
-
-Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
 
 This RFC proposes adding a new cargo flag, `--rustflag`, which accepts a pairing of `crate:RUSTFLAG` that instructs cargo to set the
 given flag when invoking rustc for the crate specified. This allows setting a Rust compiler flag for local crates as well as upstream
@@ -32,12 +31,12 @@ dependencies. Setting a specific Rust compiler flag for the standard libraries i
 
 ## An example: code coverage
 
-The Rust compiler currently supports instrumenting Rust built libraries to measure code coverage for a given crate via test runs.
-In order to instruct rustc to instrument a given crate, a user would need to pass the `-Cinstrument-coverage` flag to the invocation
-of rustc when building said crate. This can be done via the `RUSTFLAGS` environment variable but this would have the side effect of
-enabling this flag for every crate in the dependency graph including upstream dependencies, transitive dependencies, as well as the
-standard libraries. There are a couple of other options for setting Rust compiler flags but most of them have the same issue as using
-the `RUSTFLAGS` environment variable.
+The Rust compiler currently supports instrumenting Rust built libraries to measure code coverage for a given crate through tests.
+In order to instruct rustc to instrument a given crate, a user would need to pass the Rust compiler flag `-Cinstrument-coverage`
+to the invocation of rustc when building said crate. This can be done via the `RUSTFLAGS` environment variable but this would have
+the side effect of enabling this flag for every crate in the dependency graph including upstream dependencies, transitive dependencies,
+as well as the standard libraries. There are a couple of other options for setting Rust compiler flags but most of them have the
+same issue as using the `RUSTFLAGS` environment variable.
 
 Another way of setting a rustc flag for a specific crate is through the `cargo rustc` subcommand. A Rust compiler flag can be passed
 directly to rustc by setting it as an argument directly to the rustc compiler. For example:
@@ -46,22 +45,51 @@ directly to rustc by setting it as an argument directly to the rustc compiler. F
 cargo rustc -- -Cinstrument-coverage
 ```
 
-This example will pass the flag `-Cinstrument-coverage` directly to rustc but only for the current crate. Also running another cargo command
+This example will pass the flag `-Cinstrument-coverage` directly to rustc but only for the current crate. Running another cargo command
 after this will cause a new build of the crate without the flag. For example running `cargo test` will cause the crate to be re-compiled
-without the rustc flag and cause tests to be run without first instrumenting any of the libraries.
+without the rustc flag `-Cinstrument-coverage` specified. This would cause tests to be run without first instrumenting any of the libraries
+thus losing out on collecting any code coverage.
 
 ## --rustflag
 
-The `--rustflag` option will allow a Rust developer to pass any rustc flag to the crate of their choosing. This will allow a simple
+The `--rustflag` option will allow a Rust developer to pass any rustc flag to the root crate being built. This will allow a simple
 command such as `cargo test` to have the option of setting the `-Cinstrument-coverage` flag for a single crate and run the unit tests
-ensuring coverage data is collected. For example, let's take crate `foo`:
+ensuring coverage data is collected for this crate and this crate only. For example, let's take crate `foo`:
 
-```
-cargo test --rustflags foo:-Cinstrument-coverage
+Cargo.toml:
+```toml
+[package]
+name = "foo"
+version = "0.1.0"
 ```
 
-Running this command will build the crate `foo` with the flag `-Cinstrument-coverage` passed only to the invocation of rustc for crate `foo`.
-Any and all dependencies would not have this flag enabled, forcing coverage data to only be collected for this crate and not for dependencies. This will also run the tests for said crate generating coverage data for each test executed.
+cargo cli:
+```
+cargo test --rustflag=-Cinstrument-coverage
+```
+
+will result in the following input:
+```
+Compiling foo v0.1.0 (D:\projects\foo)
+     Running `rustc --crate-name foo --edition=2021 src\lib.rs --crate-type lib ... -Cinstrument-coverage`
+     Running `rustc --crate-name foo --edition=2021 src\lib.rs --test ... -Cinstrument-coverage`
+    Finished test [unoptimized + debuginfo] target(s) in 1.35s
+     Running `target/debug/deps/foo-669448d9b4043564`
+
+running 1 test
+test tests::it_works ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+Running this command will build the crate `foo` with the flag `-Cinstrument-coverage` passed to the invocation of rustc
+for crate `foo`. Dependencies such as the standard libraries and other upstream dependencies would not be instrumented
+saving on compilation time.
+
+## --rustflag for a workspace
+
+When building a workspace with multiple members
+
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -94,6 +122,8 @@ cargo option would only affect the root crate or the members of the current work
 ### Alternative 1: existing build.rustflags manifest key
 
 ### Alternative 2: existing RUSTFLAGS environment variable
+
+### Alternative 3: new build.<crate_name>.rustflags manifest key
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -7,8 +7,8 @@
 [summary]: #summary
 
 This RFC aims to improve the experience of enabling Rust compiler flags for specific crates when building Rust projects
-by adding a new option, `--rustflag=<RUSTFLAG>`. This would have the same effect as `cargo rustc -- <RUSTFLAG>` but would
-also be available for use by other subcommands such as `bench, build, check, run` and `test` thus allowing a Rust project
+by adding a new option, `--rustflags <RUSTFLAGS>`. This would have the same effect as `cargo rustc -- <RUSTFLAGS>` but would
+also be available for use by other subcommands such as `bench, build, check, run` and `test`. This allows a Rust project
 to be built and tested for instance without forcing a new compilation and losing the rustflags that were set when invoking
 `cargo rustc`.
 
@@ -18,44 +18,65 @@ to be built and tested for instance without forcing a new compilation and losing
 Today, there currently exists multiple ways of specifying `RUSTFLAGS` to pass to invocations of the Rust compiler.
 All of the existing ways have the limitation of not being able to specify which invocation of rustc the compiler flag
 is set for. When a Rust developer tries to enable a Rust compiler option for the current crate being built, they will also
-have this compiler option set for all dependencies including the standard libraries. With the feature proposed by this RFC,
-a Rust developer can simply use Cargo CLI to pass rustflags for a given crate without the need to worry about how other crates
-might be affected.
+have this compiler option set for all dependencies. With the feature proposed by this RFC, a Rust developer can simply use
+the cargo CLI to pass rustflags for a given crate without having to worry about how other crates in dependency graph might be
+affected.
+
+Some of the existing support for rustflags in Cargo are:
+
+1. `CARGO_ENCODED_RUSTFLAGS` environment variable
+2. `RUSTFLAGS` environment variable
+3. `target.*.rustflags` from the config (.cargo/config)
+4. `target.cfg(..).rustflags` from the config (.cargo/config)
+5. `host.*.rustflags` from the config (.cargo/config) if compiling a host artifact or without `--target`
+6. `build.rustflags` from the config (.cargo/config)
+
+These currently all override one another in the order specified, meaning if `CARGO_ENCODED_RUSTFLAGS` is set, none of the other rustflags
+options are even considered. The same is true if `CARGO_ENCODED_RUSTFLAGS` is not set but `RUSTFLAGS` is, and so on down the list. All of
+these options work in a very similar manner that they are applied for not just the current crate but also all dependencies for said crate
+including transitive dependencies. In the case of the `target.*.rustflags` or `host.*.rustflags` these only apply if the target triple
+specified in the manifest file matches the target triple used as the host or target.
+
+Another supported way of setting rustflags in cargo is the `profile.rustflags` manifest key that can be set in a `Cargo.toml`. This
+works in a slightly different manner than the ways mentioned previously in that it is appended to the set of rustflags calculated from
+the environment variables and cargo config settings. It still has the same limitation in that it is applied to all invocations of rustc
+including dependencies.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-This RFC proposes adding a new cargo flag, `--rustflag=<RUSTFLAG>`, which would instruct cargo to pass the given flag when invoking rustc
-for the current crate being compiled. This allows setting a Rust compiler flag for local crates only and not forcing this upon
-dependencies including transitive dependencies and standard libraries.
+This RFC proposes adding a new cargo flag, `--rustflags <RUSTFLAGS>`, which would instruct cargo to pass the specified rustflags when
+invoking rustc for the current crate being compiled. This allows setting a Rust compiler flag for local crates only and not forcing this
+upon dependencies including transitive dependencies.
 
 ## An example: code coverage
 
 The Rust compiler supports instrumenting Rust built libraries to measure code coverage for a given crate through tests.
-In order to instruct rustc to instrument a given crate, a user would need to pass the Rust compiler flag `-Cinstrument-coverage`
+In order to instruct rustc to instrument a given crate, a user would need to pass the Rust compiler flag `-C instrument-coverage`
 to the invocation of rustc when building said crate. This can be done via the `RUSTFLAGS` environment variable but this would have
 the side effect of enabling this flag for every crate in the dependency graph including upstream dependencies, transitive dependencies,
 as well as the standard libraries. There are a couple of other options for setting Rust compiler flags but most of them have the
 same issue as using the `RUSTFLAGS` environment variable.
 
 Another way of setting a rustc flag for a specific crate is through the `cargo rustc` subcommand. A Rust compiler flag can be passed
-to the invocation of rustc by cargo for the current crate being built by setting it as an argument directly to the rustc compiler.
+to the invocation of rustc by cargo for the current crate being built by setting it as an argument directly to rustc.
+
 For example:
 
 ```
-cargo rustc -- -Cinstrument-coverage
+cargo rustc -- -C instrument-coverage
 ```
 
-This example will pass the flag `-Cinstrument-coverage` directly to rustc but only for the current crate. Running another cargo command
+This example will pass the flag `-C instrument-coverage` directly to rustc but only for the current crate. Running another cargo command
 after this will cause a new build of the crate without the flag. For example running `cargo test` will cause the crate to be re-compiled
-without the rustc flag `-Cinstrument-coverage` specified. This would cause tests to be run without first instrumenting any of the libraries
-thus losing out on collecting any code coverage.
+without the rustc flag `-C instrument-coverage` specified. This would cause tests to be run without first instrumenting any of the
+libraries thus losing out on collecting any code coverage.
 
-## --rustflag
+## --rustflags
 
-The `--rustflag` option will allow a Rust developer to pass any rustc flag to the root crate being built. This will allow a simple
-command such as `cargo test` to have the option of setting the `-Cinstrument-coverage` flag for a single crate and run the unit tests
-ensuring coverage data is collected for this crate and this crate only. For example, let's take crate `foo`:
+The `--rustflags` option will allow a Rust developer to pass any set of rustc flags to the root crate being built. This will allow a
+simple command such as `cargo test` to have the option of setting the `-C instrument-coverage` flag for a single crate and run the unit
+tests ensuring coverage data is collected for this crate and this crate only. For example, let's take crate `foo`:
 
 Cargo.toml:
 ```toml
@@ -66,11 +87,11 @@ version = "0.1.0"
 
 cargo CLI (Output lines have been removed for simplicity):
 ```
-cargo test --rustflag=-Cinstrument-coverage
+cargo test --rustflags -C instrument-coverage ;
 
 Compiling foo v0.1.0 (...)
-     Running `rustc --crate-name foo --edition=2021 src\lib.rs --crate-type lib ... -Cinstrument-coverage`
-     Running `rustc --crate-name foo --edition=2021 src\lib.rs --test ... -Cinstrument-coverage`
+     Running `rustc --crate-name foo --edition=2021 src/lib.rs --crate-type lib ... -C instrument-coverage`
+     Running `rustc --crate-name foo --edition=2021 src/lib.rs --test ... -C instrument-coverage`
     Finished test [unoptimized + debuginfo] target(s) in 1.35s
      Running `target/debug/deps/foo-669448d9b4043564`
 
@@ -80,13 +101,39 @@ test tests::it_works ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
 ```
 
-Running this command will build the crate `foo` with the flag `-Cinstrument-coverage` passed to the invocation of rustc
-for the crate `foo`. Dependencies such as the standard libraries and other upstream dependencies would not be instrumented
-saving on compilation time.
+Running this command will build the crate `foo` with the flag `-C instrument-coverage` passed to the invocation of rustc
+for the crate `foo` only. Upstream dependencies would not be instrumented as well as the standard libraries, which is not the case
+now, saving on compilation time.
 
-## --rustflag for a workspace
+## --rustflags for a workspace
 
-When building a workspace with multiple members, any `--rustflag=<RUSTFLAG>` options set will be passed to the invocation
+Cargo supports two types of [workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html), a workspace with a root package and
+a workspace with a virtual manifest, meaning a "primary" package does not exist.
+
+For workspaces that contain a root package, any `--rustflags <RUSTFLAGS>` options set will be passed to the invocation of the Rust
+compiler for the root crate only. If the `workspace.default-members` manifest key has been set, then only the members listed as a
+default member will have the `--rustflags` values passed to the invocation of rustc.
+
+Cargo.toml:
+```toml
+[package]
+name = "foo"
+
+[workspace]
+members = ["bar", "baz"]
+default-members = ["bar"]
+```
+
+cargo CLI (Output lines have been removed for simplicity):
+```
+cargo build --rustflags -C instrument-coverage -C strip=symbols ;
+
+Compiling bar v0.1.0 (.../foo/bar)
+    Running `rustc --crate-name bar ... -C instrument-coverage -C strip=symbols`
+Finished dev [unoptimized + debuginfo] target(s) in 0.98s
+```
+
+For workspaces that do not contain a root package, any `--rustflags <RUSTFLAGS>` options set will be passed to the invocation
 of the Rust compiler for all members unless `workspace.default-members` manifest key has been set. In that case, only the default
 members being compiled will have the rustflag options specified passed through to rustc. For example:
 
@@ -98,24 +145,29 @@ members = ["foo", "bar"]
 
 cargo CLI (Output lines have been removed for simplicity):
 ```
-cargo build --rustflag=-Cinstrument-coverage
+cargo build --rustflags -C instrument-coverage ;
 
 Compiling foo v0.1.0 (.../foo/foo)
 Compiling bar v0.1.0 (.../foo/bar)
-    Running `rustc --crate-name foo ... -Cinstrument-coverage`
-    Running `rustc --crate-name bar ... -Cinstrument-coverage`
+    Running `rustc --crate-name foo ... -C instrument-coverage`
+    Running `rustc --crate-name bar ... -C instrument-coverage`
 Finished dev [unoptimized + debuginfo] target(s) in 0.98s
 ```
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-As mentioned above a new Cargo option, `--rustflag=<RUSTFLAG>`, would be added to several of the existing cargo subcommands.
-Those subcommands would be, `bench, build, check, run` and `test`. The `--rustflag=<RUSTFLAG>` option will require an `=`
-sign between the option name and the option value, due to the way Cargo parses the options passed to its subcommands. Cargo under
+As mentioned above a new Cargo option, `--rustflags <RUSTFLAGS>`, would be added to several of the existing cargo subcommands.
+Those subcommands would be, `bench, build, check, run` and `test`. The `--rustflags <RUSTFLAGS>` option will require the use of
+a [value terminator](https://docs.rs/clap/3.2.18/clap/builder/struct.Arg.html#method.value_terminator), `;`. Cargo under
 the covers uses the `clap` crate to parse the command line invocation and set the relevant options passed to it. Since all rust
-compiler flags start with a `-`, without the `=` delimitter `clap` parses the rustc flag as a new Cargo flag instead leading to
-an error from Cargo.
+compiler flags start with a `-`, this change instructs the `clap` parser to allow values that begin with a `-` for this new option.
+Without using the `;` value terminator at the end of the `<RUSTFLAGS>` list, any cargo flags that come after this would be interpreted
+as more rustflags instead, leading to potential errors from the Rust compiler.
+
+This feature also support quoting a rustflag in the same manner the Rust compiler does. This means that any `<RUSTFLAG>` which would
+need to wrap its value with quotes can be done so via the `--rustflag` option. This would allow supporting flags that may contain spaces
+or commas.
 
 For each rustc flag specified by a Rust developer, Cargo will pass the flag through to the invocation of rustc for the current crate.
 This includes all invocations of rustc for a given crate including all targets, such as, lib, bin, examples and the test targets
@@ -130,14 +182,14 @@ version = "0.1.0
 
 cargo CLI (Output lines have been removed for simplicity):
 ```
-cargo test --rustflag=-Cinstrument-coverage
+cargo test --rustflags -C instrument-coverage ;
 
-Compiling foo v0.1.0 (D:\projects\foo)
-    Running `rustc --crate-name foo --edition=2021 src\lib.rs ... --crate-type lib -Cinstrument-coverage`
-    Running `rustc --crate-name foo --edition=2021 src\lib.rs --test ... -Cinstrument-coverage`
-    Running `rustc --crate-name bin1 --edition=2021 src\bin\bin1.rs ... -Cinstrument-coverage`
-    Running `rustc --crate-name example --edition=2021 examples\example.rs... --crate-type bin -Cinstrument-coverage`
-    Running `rustc --crate-name foo --edition=2021 src\main.rs --test ... -Cinstrument-coverage`
+Compiling foo v0.1.0 (foo)
+    Running `rustc --crate-name foo --edition=2021 src/lib.rs ... --crate-type lib -C instrument-coverage`
+    Running `rustc --crate-name foo --edition=2021 src/lib.rs --test ... -C instrument-coverage`
+    Running `rustc --crate-name bin1 --edition=2021 src/bin/bin1.rs ... -C instrument-coverage`
+    Running `rustc --crate-name example --edition=2021 examples/example.rs... --crate-type bin -C instrument-coverage`
+    Running `rustc --crate-name foo --edition=2021 src/main.rs --test ... -C instrument-coverage`
 Finished test [unoptimized + debuginfo] target(s) in 1.51s
     Running `.../debug/deps/foo-669448d9b4043564`
 
@@ -146,7 +198,7 @@ test tests::it_works ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
 
-    Running `.../target/debug/deps\bin1-88f2f72473b4679f`
+    Running `.../target/debug/deps/bin1-88f2f72473b4679f`
 
 running 0 tests
 
@@ -167,33 +219,23 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ```
 
 In the example above, the only invocation which does not include the user specified rustc flags is the invocation of
-`rustdoc`. Since `rustdoc` flags are treated different than normal `rustflags`, the flags specifed through `--rustflag=<RUSTFLAG>`
+`rustdoc`. Since `rustdoc` flags are treated different than normal `rustflags`, the flags specifed through `--rustflags <RUSTFLAGS>`
 will not be passed to the invocation of `rustdoc`.
 
 ## Build scripts
 
-The new `--rustflag=<RUSTFLAG>` feature will not be passed to the invocation of rustc for build scripts that are being compiled and run
+The new `--rustflags <RUSTFLAGS>` feature will not be passed to the invocation of rustc for build scripts that are being compiled and run
 on the host. This is currently out of scope for this RFC since rustc flags are treated differently for build scripts depending on cargo
 configuration settings as well as the target specified.
 
 ## Integration with existing RUSTFLAGS
 
-In Cargo there exists numerous ways to specify which Rust compiler flags should be set when compiling a crate and its dependencies.
+As mentioned above, there exists numerous ways of setting rustflags in cargo. The values passed to the `--rustflags` option would
+be appended to the set of rustflags calculated from the options listed above only for the current crate or the set of crates in the
+workspace. All upstream and transitive dependencies will still use the rustflags calculated from the environment variables and cargo
+config only.
 
-1. `CARGO_ENCODED_RUSTFLAGS` environment variable
-2. `RUSTFLAGS` environment variable
-3. `target.*.rustflags` from the config (.cargo/config)
-4. `target.cfg(..).rustflags` from the config (.cargo/config)
-5. `host.*.rustflags` from the config (.cargo/config) if compiling a host artifact or without `--target`
-6. `build.rustflags` from the config (.cargo/config)
-
-The `--rustflag` values would override the set of rustflags calculated from the options listed above only for the current crate or the set of crates in the workspace. All upstream and transitive dependencies will still use the rustflags calculated from the environment
-variables and cargo config.
-
-As of today, the `profile.rustflags` manifest key is appended to the set of rustflags calculated from the environment variables and
-cargo config settings. With the addition of the `--rustflag=<RUSTFLAG>` feature, the `profile.rustflags` compiler options will work in
-the same manner and be appended to the invocation of `rustc`. The user specified command line rustflags will not override the values of
-the `profile.rustflags` values.
+The `profile.rustflags` manifest key is appended to the set of rustflags calculated from the environment variables and cargo config settings, this behavior will not change with the addition of the `--rustflags <RUSTFLAGS>` flag.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -214,7 +256,7 @@ dependencies, to be built in the same manner. As with the given example above, s
 the rustc flag `-C instrument-coverage` forces the compiler to do an extra amount
 of work to instrument all of the libraries in a given crate. If this flag was passed
 for all transitive dependencies, that would only add to the amount of work that needs
-to be done by the compiler. With this new feature, the rustc flags set via the `--rustflag`
+to be done by the compiler. With this new feature, the rustc flags set via the `--rustflags`
 cargo option would only affect the root crate or the members of the current workspace.
 
 ## Alternatives
@@ -231,11 +273,25 @@ would be instrumented leading to larger code coverage files and more compilation
 
 This alternative proposes another way to implement such a feature that would allow a Rust developer to specify through cargo
 configuration files exactly which crate enables which Rust compiler flag. There already exists a `rustflags` key under the
-`[build]` section of the cargo configuraiton file and this would add to that existing pattern to enable selective enabling
-rustc flags. An issue with this approach is that changes to the config file is more cumbersome than simply adding commands at
-the CLI. This approach I believe would also make it the feature more complicated in cases where a Rust developer wants to
+`[build]` section of the cargo configuraiton file and this would add to that existing pattern of selectively enabling
+rustc flags.
+
+This approach has the benefit of extensibility. This meaning it can easily be expanded upon to support crate specific rustflags
+for the root crate being built as well dependencies in the dependency graph by updating the crate name in the manifest section.
+For instance, supporting `build.foo.rustflags` would also make it simpler to support `build.dependency.rustflags` as well.
+
+An issue with this approach is that changes to the config file is more cumbersome than simply adding commands at
+the CLI. This approach I believe would also make the feature more complicated in cases where a Rust developer wants to
 enable a specific flag for a set of crates such as the crates within a given workspace. This approach would mean each crate
 would need a separate section in the cargo configuration file to enable said rustc flag.
+
+### Alternative 3: override existing RUSTFLAGS value with --rustflags
+
+The feature proposed by this RFC suggests combining the RUSTFLAGS calculated by cargo from environment variables and manifest files
+with the values specified by the `--rustflags` cargo option. An alternative would be to override any of Cargos default logic for
+collecting rustflags when the `--rustflags` option is set for a given crate. This allows for the possibility for contradicting
+`RUSTFLAGS` to be set by the user via the `--rustflags` option and have it only apply for that crate but leave `RUSTFLAGS` unotuched
+for dependencies of said crate.
 
 # Prior art
 [prior-art]: #prior-art
@@ -251,12 +307,12 @@ for a simple `cargo run` and especially when running tests via `cargo test`.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-1. Should the cargo feature `--rustflag=<RUSTFLAG>` be dependent on the existing unstable cargo feature `-Ztarget-applies-to-host` to determine whether or not the rustc flags specified by the user on the cargo CLI should be passed to the invocation of rustc for build scripts defined in a given crate?
+1. Should the cargo feature `--rustflags <RUSTFLAGS>` be dependent on the existing unstable cargo feature `-Z target-applies-to-host` to determine whether or not the rustc flags specified by the user on the cargo CLI should be passed to the invocation of rustc for build scripts defined in a given crate?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-## Crate specific --rustflag
+## Crate specific --rustflags
 
 A natural extension to this feature would be to add support for specifying specific crates a Rust compiler flag should be enabled for.
 For example, if in a given workspace there exists 2 default members, `foo` and `bar`, having the ability to set rustc flags only for the
@@ -264,26 +320,27 @@ crate `foo` and not for the crate `bar`. An example of said feature would be:
 
 cargo CLI (Output lines have been removed for simplicity):
 ```
-cargo build --rustflag=foo:-Cstrip=debuginfo
+cargo build --rustflags foo:-C strip=debuginfo ;
 ```
 
-This would result in the `foo` crate stripping away all debuginfo and not included in the generated binary and/or `PDB`. This would not have the same effect on the `bar` crate or any other upstream dependencies.
+This would result in the `foo` crate stripping away all debuginfo from the generated binary and/or `PDB`. This would not have the same
+effect on the `bar` crate or any other upstream dependencies.
 
-## --rustflag support for dependencies
+## --rustflags support for dependencies
 
 Allowing a Rust developer to manually specify which rustflags are passed to upstream dependencies seems like a natural extension of this
-feature. As with the above mentioned future possibilities, `--rustflag=<crate_name>:<RUSTFLAG>`, would be sufficient for adding support
+feature. As with the above mentioned future possibilities, `--rustflags <crate_name>:<RUSTFLAG>`, would be sufficient for adding support
 for specifying rustc flags for upstream dependency. If a crate is selected which does not exist, or which has not been pulled in as a
 dependency, then an warning would be raised notifying the user that the specified rustc flag was unused. A simple use case for this would
 be allowing the instrumentation of targeted upstream dependencies or local dependencies through the use of the `-C instrument-coverage`
 rustc feature.
 
-## --rustflag support for build scripts
+## --rustflags support for build scripts
 
-The feature proposed by this RFC does not extend any support to passing Rust compiler flags specified by the `--rustflag` feature to
+The feature proposed by this RFC does not extend any support to passing Rust compiler flags specified by the `--rustflags` feature to
 invocations of rustc when compiling build scripts. There is support today for setting rustc flags for build scripts depending on certain
-configuration settings such as, whether the host and target triples match, and/or if the unstable `-Ztarget-applies-to-host` flag has
+configuration settings such as, whether the host and target triples match, and/or if the unstable `-Z target-applies-to-host` flag has
 been enabled and the `[host]`/`[build]` sections have the `rustflags` manifest key set.
 
-Allowing a mechanism for setting rustc flags for build scripts via the `--rustflag` cargo feature would extend the flexibility of
+Allowing a mechanism for setting rustc flags for build scripts via the `--rustflags` cargo feature would extend the flexibility of
 setting compiler flags from the cargo CLI.

--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -1,0 +1,115 @@
+- Feature Name: `rustflag`
+- Start Date: 2022-08-18
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+This RFC aims to improve the experience of enabling user specified Rust compiler flags
+when invoking a build of a Rust project through Cargo, which most Rust developers use
+to build their project. This feature would allow a Rust developer to selectively choose
+which rustc flags are set when inoking the Rust compiler for a given crate.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+Running a build of a Rust project via Cargo, there are limitations on trying to set Rust compiler flags. Since Cargo is aware of
+all crates being built in the dependency graph, cargo is properly positioned to be able to set Rust compiler flags  
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+This RFC proposes adding a new cargo flag, `--rustflag`, which accepts a pairing of `crate:RUSTFLAG` that instructs cargo to set the
+given flag when invoking rustc for the crate specified. This allows setting a Rust compiler flag for local crates as well as upstream
+dependencies. Setting a specific Rust compiler flag for the standard libraries is currently out of scope for this RFC.
+
+## An example: code coverage
+
+The Rust compiler currently supports instrumenting Rust built libraries to measure code coverage for a given crate via test runs.
+In order to instruct rustc to instrument a given crate, a user would need to pass the `-Cinstrument-coverage` flag to the invocation
+of rustc when building said crate. This can be done via the `RUSTFLAGS` environment variable but this would have the side effect of
+enabling this flag for every crate in the dependency graph including upstream dependencies, transitive dependencies, as well as the
+standard libraries. There are a couple of other options for setting Rust compiler flags but most of them have the same issue as using
+the `RUSTFLAGS` environment variable.
+
+Another way of setting a rustc flag for a specific crate is through the `cargo rustc` subcommand. A Rust compiler flag can be passed
+directly to rustc by setting it as an argument directly to the rustc compiler. For example:
+
+```
+cargo rustc -- -Cinstrument-coverage
+```
+
+This example will pass the flag `-Cinstrument-coverage` directly to rustc but only for the current crate. Also running another cargo command
+after this will cause a new build of the crate without the flag. For example running `cargo test` will cause the crate to be re-compiled
+without the rustc flag and cause tests to be run without first instrumenting any of the libraries.
+
+## --rustflag
+
+The `--rustflag` option will allow a Rust developer to pass any rustc flag to the crate of their choosing. This will allow a simple
+command such as `cargo test` to have the option of setting the `-Cinstrument-coverage` flag for a single crate and run the unit tests
+ensuring coverage data is collected. For example, let's take crate `foo`:
+
+```
+cargo test --rustflags foo:-Cinstrument-coverage
+```
+
+Running this command will build the crate `foo` with the flag `-Cinstrument-coverage` passed only to the invocation of rustc for crate `foo`.
+Any and all dependencies would not have this flag enabled, forcing coverage data to only be collected for this crate and not for dependencies. This will also run the tests for said crate generating coverage data for each test executed.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Multiple ways of setting rustflags already, this would add another way and would have to work
+with all of the existing ways.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Rationale
+
+This design provides a simple mechanism to specify the set of Rust compiler flags
+a given crate should be built with. This design also has teh benefit of not forcing
+all crates in the dependency graph, including upstream dependencies and transitive
+dependencies, to be built in the same manner. As with the given example above, setting
+the rustc flag `-C instrument-coverage` forces the compiler to do an extra amount
+of work to instrument all of the libraries in a given crate. If this flag was passed
+for all transitive dependencies, that would only add to the amount of work that needs
+to be done by the compiler. With this new feature, the rustc flags set via the `--rustflag`
+cargo option would only affect the root crate or the members of the current workspace.
+
+## Alternatives
+
+### Alternative 1: existing build.rustflags manifest key
+
+### Alternative 2: existing RUSTFLAGS environment variable
+
+# Prior art
+[prior-art]: #prior-art
+
+### Rustflags manifest keys
+
+### cargo rustc subcommand
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+## Crate specific --rustflag
+
+## --rustflag support for dependencies
+
+## --rustflag support for build scripts and proc-macros

--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -169,11 +169,26 @@ In the example above, the only invocation which does not include the user specif
 `rustdoc`. Since `rustdoc` flags are treated different than normal `rustflags`, the flags specifed through `--rustflag=<RUSTFLAG>`
 will not be passed to the invocation of `rustdoc`.
 
-## Build scripts and proc-macros
+## Build scripts
 
-The new `--rustflag=<RUSTFLAG>` feature will only be passed to targets that are not being compiled for the host. Build scripts and
-proc-macros which are being used a dependency for the current crate
+The new `--rustflag=<RUSTFLAG>` feature will not be passed to build scripts that are being compiled and run on the host. This currently
+out of scope for this RFC since rustc flags are treated differently for build scripts depending on cargo configuration settings as well
+as the target specified.
 
+## Integration with existing RUSTFLAGS
+
+In Cargo there exists numerous ways to specify which Rust compiler flags should be set when compiling a crate and its dependencies.
+
+1. `CARGO_ENCODED_RUSTFLAGS` environment variable
+2. `RUSTFLAGS` environment variable
+3. `target.*.rustflags` from the config (.cargo/config)
+4. `target.cfg(..).rustflags` from the config (.cargo/config)
+5. `host.*.rustflags` from the config (.cargo/config) if compiling a host artifact or without `--target`
+6. `build.rustflags` from the config (.cargo/config)
+7. `profile.rustflags` from the cargo manifest (Cargo.toml)
+
+The `--rustflag` values would be appended to set of rustflags calculated from the options listed above. If the same Rust compiler flags
+are specified multiple times through different means which are not allowed, a compiler error would be generated.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -198,11 +213,9 @@ cargo option would only affect the root crate or the members of the current work
 
 ## Alternatives
 
-### Alternative 1: existing build.rustflags manifest key
+### Alternative 1: existing RUSTFLAGS manifest keys
 
-### Alternative 2: existing RUSTFLAGS environment variable
-
-### Alternative 3: new build.<crate_name>.rustflags manifest key
+### Alternative 2: new build.<crate_name>.rustflags manifest key
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -41,7 +41,8 @@ as well as the standard libraries. There are a couple of other options for setti
 same issue as using the `RUSTFLAGS` environment variable.
 
 Another way of setting a rustc flag for a specific crate is through the `cargo rustc` subcommand. A Rust compiler flag can be passed
-directly to rustc by setting it as an argument directly to the rustc compiler. For example:
+to the invocation of rustc by cargo for the current crate being built by setting it as an argument directly to the rustc compiler.
+For example:
 
 ```
 cargo rustc -- -Cinstrument-coverage

--- a/text/0000-rustflags.md
+++ b/text/0000-rustflags.md
@@ -63,14 +63,14 @@ name = "foo"
 version = "0.1.0"
 ```
 
-cargo cli:
+cargo CLI:
 ```
 cargo test --rustflag=-Cinstrument-coverage
 ```
 
-will result in the following input:
+Output (lines have been removed for simplicity):
 ```
-Compiling foo v0.1.0 (D:\projects\foo)
+Compiling foo v0.1.0 (...)
      Running `rustc --crate-name foo --edition=2021 src\lib.rs --crate-type lib ... -Cinstrument-coverage`
      Running `rustc --crate-name foo --edition=2021 src\lib.rs --test ... -Cinstrument-coverage`
     Finished test [unoptimized + debuginfo] target(s) in 1.35s
@@ -83,12 +83,14 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ```
 
 Running this command will build the crate `foo` with the flag `-Cinstrument-coverage` passed to the invocation of rustc
-for crate `foo`. Dependencies such as the standard libraries and other upstream dependencies would not be instrumented
+for the crate `foo`. Dependencies such as the standard libraries and other upstream dependencies would not be instrumented
 saving on compilation time.
 
 ## --rustflag for a workspace
 
-When building a workspace with multiple members
+When building a workspace with multiple members, any `--rustflag=<RUSTFLAG>` options set will be passed to the invocation
+of the compiler for all members unless `workspace.default-members` manifest key has been set. In that case, only the default
+members being compiled will have the rustflags passed to rustc.
 
 
 # Reference-level explanation


### PR DESCRIPTION
This RFC proposes a new Cargo feature `--rustflag=<RUSTFLAG>` which allows for setting Rust compiler flags through cargo. This new makes it possible for specifying rustc flags only for the root crate or the set of root crates if compiling a workspace.